### PR TITLE
fix(templates/listItem): escape % in CSS filter values for vsprintf compatibility

### DIFF
--- a/lib/templates/email/ionos/listItem.html
+++ b/lib/templates/email/ionos/listItem.html
@@ -24,7 +24,7 @@
                                 <td width="15">
                                     <p style="padding:2px 0 0 0;margin:0;text-align:left;line-height:20px">
 										<!-- List item icon -->
-										<span style="color:#000000;fill:#000000;filter:brightness(0) saturate(100%) invert(0%);">%s</span>
+										<span style="color:#000000;fill:#000000;filter:brightness(0) saturate(100%%) invert(0%%);">%s</span>
                                     </p>
                                 </td>
                                 <td class="w-10 minw-10" style="min-width:10px;width:10px;line-height:1px;font-size:0px">


### PR DESCRIPTION
### Summary
The filter CSS property in the IONOS listItem.html template contained unescaped % characters (saturate(100%), invert(0%)).
vsprintf() attempted to interpret %) as a format specifier, causing a PHP warning and potentially corrupting the rendered output.
Escaped both occurrences to %% to match the convention already used throughout the template.
Test ### plan
- [ ] Render the listItem template via vsprintf() with valid icon and text arguments and verify no PHP warnings are produced.
- [ ] Visually verify the list item icon filter (black/forced color) renders correctly in an email client.