### PR TITLE
chore: bump nextcloud/ocp to dev-stable32 (NSW-946)

### DIFF
--- a/.github/workflows/block-unconventional-commits.yml
+++ b/.github/workflows/block-unconventional-commits.yml
@@ -23,7 +23,7 @@ jobs:
   block-unconventional-commits:
     name: Block unconventional commits
 
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/fixup.yml
+++ b/.github/workflows/fixup.yml
@@ -27,7 +27,7 @@ jobs:
       pull-requests: write
     name: Block fixup and squash commits
 
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
 
     steps:
       - name: Run check

--- a/.github/workflows/lint-eslint.yml
+++ b/.github/workflows/lint-eslint.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
@@ -87,7 +87,7 @@ jobs:
   summary:
     permissions:
       contents: none
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
     needs: [changes, lint]
 
     if: always()

--- a/.github/workflows/lint-php.yml
+++ b/.github/workflows/lint-php.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   matrix:
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
     outputs:
       php-versions: ${{ steps.versions.outputs.php-versions }}
     steps:
@@ -63,7 +63,7 @@ jobs:
   summary:
     permissions:
       contents: none
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
     needs: php-lint
 
     if: always()

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   changes:
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
@@ -94,7 +94,7 @@ jobs:
   summary:
     permissions:
       contents: none
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
     needs: [changes, build]
 
     if: always()

--- a/.github/workflows/psalm-matrix.yml
+++ b/.github/workflows/psalm-matrix.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   matrix:
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
     outputs:
       ocp-matrix: ${{ steps.versions.outputs.ocp-matrix }}
     steps:
@@ -75,7 +75,7 @@ jobs:
         run: composer run psalm -- --threads=1 --monochrome --no-progress --output-format=github
 
   summary:
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
     needs: static-analysis
 
     if: always()

--- a/.github/workflows/update-nextcloud-ocp-approve-merge.yml
+++ b/.github/workflows/update-nextcloud-ocp-approve-merge.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   auto-approve-merge:
     if: github.actor == 'nextcloud-command'
-    runs-on: ubuntu-latest-low
+    runs-on: ubuntu-latest
     permissions:
       # for hmarr/auto-approve-action to approve PRs
       pull-requests: write

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"php": "^8.1"
 	},
 	"require-dev": {
-		"nextcloud/ocp": "dev-stable31",
+		"nextcloud/ocp": "dev-stable32",
 		"roave/security-advisories": "dev-latest"
 	},
 	"config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "abb91d50d65929bcd32eb91908d6dc7d",
+    "content-hash": "305c3d9dbeea41e78c68065a07fed50e",
     "packages": [
         {
             "name": "bamarni/composer-bin-plugin",
@@ -67,16 +67,16 @@
     "packages-dev": [
         {
             "name": "nextcloud/ocp",
-            "version": "dev-stable31",
+            "version": "dev-stable32",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "71cd0e748626ebf63e5f4614bc8745a3e69e615b"
+                "reference": "69c9d06aa3e899dfb74d6c035951dbc7613f2649"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/71cd0e748626ebf63e5f4614bc8745a3e69e615b",
-                "reference": "71cd0e748626ebf63e5f4614bc8745a3e69e615b",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/69c9d06aa3e899dfb74d6c035951dbc7613f2649",
+                "reference": "69c9d06aa3e899dfb74d6c035951dbc7613f2649",
                 "shasum": ""
             },
             "require": {
@@ -89,7 +89,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-stable31": "31.0.0-dev"
+                    "dev-stable32": "32.0.0-dev"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -109,9 +109,9 @@
             "description": "Composer package containing Nextcloud's public OCP API and the unstable NCU API",
             "support": {
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
-                "source": "https://github.com/nextcloud-deps/ocp/tree/stable31"
+                "source": "https://github.com/nextcloud-deps/ocp/tree/stable32"
             },
-            "time": "2025-09-16T00:45:42+00:00"
+            "time": "2026-08-07T02:03:41+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
## Summary

- Bump `nextcloud/ocp` from `dev-stable31` to `dev-stable32` in `composer.json` + `composer.lock`

No `appinfo/info.xml` change: the app already declares `min-version="31" max-version="32"`.

## Why

Part of the NC32 sweep over IONOS-owned apps. This app was **already NC32-compatible** — CI
Psalms it against stable32 today, because `psalm-matrix.yml` derives its matrix from `info.xml`
via `nextcloud-version-matrix` and then does `composer require --dev nextcloud/ocp:${{ matrix.ocp-version }}`.
The `composer.json` pin only affects local runs, where `composer psalm` was checking against
NC31 stubs. This aligns it.

## Audit (NC32 removed APIs)

- `OC_Helper::` — none ✅
- `OC_Template` / `OCP\Template` / `OC_Util::add*` — none ✅
- `appinfo/app.php` — absent ✅
- `/apps/files/api/v1/thumbnail` — none ✅

`php: ^8.1` and `config.platform.php: 8.1` deliberately unchanged — the app still declares
`min-version="31"`, and the constraint tracks the *lowest* supported NC.

## Spotted, not fixed here

`.github/workflows/update-nextcloud-ocp-matrix.yml` still has `target: ['stable30']`, three
majors behind. That is why this dependency drifted in the first place. Out of scope for this PR.

Jira: NSW-946